### PR TITLE
Post-rename cleanup: workflow triggers to main only (PR-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: deploy
 on:
   push:
     branches:
-      - master
       - main
   workflow_dispatch:
 


### PR DESCRIPTION
Step 2.3 of the hygiene plan. The default branch was renamed master → main; this drops the now-dead `master` entries from the `push:` triggers in `ci.yml` and `deploy.yml`. A repo-wide grep found no other live `master` references (remaining matches are third-party URLs, the `mastersthesis` BibTeX type, and a PDF filename).