### PR TITLE
Stage 1: design system — CSS tokens + dark mode

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,107 @@
+---
+/*
+ * ThemeToggle — the site's only runtime JS.
+ * Flips html[data-theme] between "light" and "dark" and persists the choice
+ * to localStorage under the key "theme". The no-flash script in BaseLayout
+ * (<head>, is:inline) reads that value before paint; this only handles clicks.
+ */
+---
+
+<button
+  type="button"
+  class="theme-toggle"
+  aria-label="Toggle dark mode"
+  title="Toggle dark mode"
+>
+  {/* shown in light mode → click to go dark */}
+  <svg
+    class="icon icon-moon"
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+
+  {/* shown in dark mode → click to go light */}
+  <svg
+    class="icon icon-sun"
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+</button>
+
+<style>
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-2);
+
+    color: var(--color-text-primary);
+    background: none;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-md);
+
+    cursor: pointer;
+  }
+
+  .theme-toggle:hover {
+    color: var(--color-link-hover);
+    border-color: var(--color-border-default);
+  }
+
+  .icon {
+    display: block;
+  }
+
+  /* Light mode shows the moon; dark mode shows the sun. */
+  .icon-sun {
+    display: none;
+  }
+
+  :global(html[data-theme="dark"]) .icon-moon {
+    display: none;
+  }
+
+  :global(html[data-theme="dark"]) .icon-sun {
+    display: block;
+  }
+</style>
+
+<script>
+  const KEY = "theme";
+  const toggles = document.querySelectorAll<HTMLButtonElement>(".theme-toggle");
+
+  for (const button of toggles) {
+    button.addEventListener("click", () => {
+      const next =
+        document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+      document.documentElement.dataset.theme = next;
+      localStorage.setItem(KEY, next);
+    });
+  }
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,138 @@
 ---
-
+import ThemeToggle from "../components/ThemeToggle.astro";
+import "../styles/main.css";
 ---
 
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
-    <title>Astro</title>
+    <title>Design system — Stage 1 demo</title>
+
+    {
+      /*
+       * No-flash theme script. Runs before paint (it is in <head>, before the
+       * body renders), so the correct theme is applied with no flash on hard
+       * refresh. is:inline keeps Astro from bundling/deferring it. This moves
+       * into BaseLayout in Stage 2. localStorage key "theme"; values
+       * "light" / "dark".
+       */
+    }
+    <script is:inline>
+      const stored = localStorage.getItem("theme");
+      const theme =
+        stored ??
+        (window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light");
+      document.documentElement.dataset.theme = theme;
+    </script>
   </head>
+
   <body>
-    <h1>Astro</h1>
+    <div class="container">
+      <div class="content">
+        <header class="demo-header">
+          <h1>Design system</h1>
+          <ThemeToggle />
+        </header>
+
+        <p>
+          Stage 1 demo page. Toggle the theme (top right) — every colour below
+          is driven by a semantic token, so light and dark swap from one place
+          in <code>tokens.css</code>. This page exists only to verify the tokens
+          and the dark-mode layer; the real layout arrives in Stage 2.
+        </p>
+
+        <h2>Type scale</h2>
+        <h3>Heading three</h3>
+        <p>
+          Body copy with a <a href="#">link in the theme colour</a> and some
+          <code>inline code</code> on a muted surface. Selecting this text shows the
+          selection colour.
+        </p>
+        <pre><code>// fenced code block on --color-bg-muted
+const theme = "easy to change";</code></pre>
+
+        <hr />
+
+        <h2>Semantic colour roles</h2>
+        <p>These swatches re-resolve when you toggle the theme.</p>
+        <div class="swatches">
+          <div class="swatch" style="background: var(--color-bg-default)">
+            bg-default
+          </div>
+          <div class="swatch" style="background: var(--color-bg-muted)">
+            bg-muted
+          </div>
+          <div class="swatch" style="background: var(--color-surface)">
+            surface
+          </div>
+          <div class="swatch on-accent" style="background: var(--color-theme)">
+            theme
+          </div>
+          <div
+            class="swatch on-accent"
+            style="background: var(--color-accent-1)"
+          >
+            accent-1 · MLSec
+          </div>
+          <div
+            class="swatch on-accent"
+            style="background: var(--color-accent-2)"
+          >
+            accent-2 · PlatSec
+          </div>
+          <div
+            class="swatch on-accent"
+            style="background: var(--color-accent-3)"
+          >
+            accent-3 · Other
+          </div>
+          <div
+            class="swatch on-accent"
+            style="background: var(--color-status-success)"
+          >
+            success
+          </div>
+          <div
+            class="swatch on-accent"
+            style="background: var(--color-status-error)"
+          >
+            error
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      .demo-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+      }
+
+      .swatches {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+        gap: var(--space-3);
+      }
+
+      .swatch {
+        padding: var(--space-4);
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-md);
+        font-size: var(--font-size-sm);
+        font-family: var(--font-mono);
+        color: var(--color-text-primary);
+      }
+
+      .swatch.on-accent {
+        color: var(--color-white);
+        border-color: transparent;
+      }
+    </style>
   </body>
 </html>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,151 @@
+/* ─────────────────────────────
+   Base styles
+   Applies design tokens to HTML primitives. No layout, no components.
+   ───────────────────────────── */
+
+html {
+  font-size: 16px;
+
+  /* Hint native UI (form controls, scrollbars) to match the active theme. */
+  color-scheme: light;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+
+  background-color: var(--color-bg-default);
+  color: var(--color-text-primary);
+
+  font-family: var(--font-sans);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ─────────────────────────────
+   Headings
+   ───────────────────────────── */
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+  margin-bottom: var(--space-4);
+
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+}
+
+h1 {
+  font-size: var(--font-size-4xl);
+}
+
+h2 {
+  font-size: var(--font-size-3xl);
+}
+
+h3 {
+  font-size: var(--font-size-2xl);
+  margin-bottom: var(--space-2);
+}
+
+h4 {
+  font-size: var(--font-size-xl);
+}
+
+h5 {
+  font-size: var(--font-size-lg);
+}
+
+h6 {
+  font-size: var(--font-size-md);
+}
+
+/* ─────────────────────────────
+   Text
+   ───────────────────────────── */
+
+p {
+  margin-top: 0;
+  margin-bottom: var(--space-5);
+  max-width: var(--max-width-md);
+}
+
+small {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ─────────────────────────────
+   Links
+   ───────────────────────────── */
+
+a {
+  color: var(--color-link);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+}
+
+/* ─────────────────────────────
+   Code
+   ───────────────────────────── */
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+code {
+  padding: 0.1em 0.3em;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-muted);
+}
+
+pre {
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-muted);
+  overflow-x: auto;
+}
+
+pre code {
+  padding: 0;
+  background: none;
+}
+
+/* ─────────────────────────────
+   Rules
+   ───────────────────────────── */
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--color-border-subtle);
+  margin-block: var(--space-6);
+}
+
+/* ─────────────────────────────
+   Selection
+   ───────────────────────────── */
+
+::selection {
+  background-color: var(--color-selection);
+  color: var(--color-white);
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,14 @@
+/* Layout primitives
+   Structural layout only (container + content). No colours, no type scale.
+*/
+
+.container {
+  width: min(100% - (2 * var(--space-6)), var(--max-width-lg));
+  margin-inline: auto;
+  padding-block: var(--space-7);
+}
+
+.content {
+  max-width: var(--max-width-md);
+  margin-inline: auto;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,0 +1,7 @@
+/* Main stylesheet
+   Design system entry point. Import this once (in BaseLayout from Stage 2).
+*/
+
+@import url("./tokens.css");
+@import url("./base.css");
+@import url("./layout.css");

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,171 @@
+/* ─────────────────────────────
+   Design tokens
+   Three layers, in order:
+     1. Raw palette   — the only place hex values live.
+     2. Semantic roles — what the site actually consumes (bg, text, link…).
+     3. Scales         — typography, spacing, radii, widths (theme-agnostic).
+   Dark mode (bottom) re-points the SOURCE roles only; everything downstream
+   re-resolves automatically because :root and html[data-theme="dark"] are the
+   same <html> element. To restyle the site, edit a role here — not a component.
+   ───────────────────────────── */
+
+:root {
+  /* ─────────────────────────────
+     1. Raw palette — al-folio defaults
+     (the previous Jekyll theme; keep the look, change here if ever wanted)
+     ───────────────────────────── */
+  --color-white: #fff;
+  --color-black: #000;
+  --color-grey: #828282; /* $grey-color */
+  --color-grey-light: #e8e8e8; /* lighten($grey-color, 40%) */
+  --color-grey-dark: #1c1c1d; /* $grey-color-dark */
+  --color-grey-900: #212529;
+
+  --color-purple: #b509ac; /* light-mode accent ($purple-color) */
+  --color-cyan: #2698ba; /* dark-mode accent ($cyan-color) */
+
+  --color-green: #00ab37; /* $green-color */
+  --color-red: #ff3636; /* $red-color */
+
+  --color-divider-light: rgb(0 0 0 / 10%);
+  --color-divider-dark: #424246;
+
+  /* ─────────────────────────────
+     2. Semantic roles — light (the source of truth)
+     ───────────────────────────── */
+
+  /* The single accent. Light = purple, dark = cyan (see dark layer).
+     Everything accent-coloured points here, so one edit recolours the site. */
+  --color-theme: var(--color-purple);
+
+  --color-bg-default: var(--color-white);
+  /* Code / inset surfaces — a faint wash of the theme colour over the page bg,
+     so changing --color-theme recolours this too (al-folio froze it to purple). */
+  --color-bg-muted: color-mix(
+    in srgb,
+    var(--color-theme) 5%,
+    var(--color-bg-default)
+  );
+  --color-surface: var(--color-white); /* cards, panels */
+
+  --color-text-primary: var(--color-black);
+  --color-text-secondary: var(--color-grey);
+  --color-text-muted: var(--color-grey);
+
+  --color-link: var(--color-theme);
+  --color-link-hover: var(--color-theme);
+  --color-selection: var(--color-theme);
+
+  /* Group accent slots — MLSec / PlatSec / Other. All point at the single theme
+     colour today (al-folio was single-accent), so they track light/dark for free.
+     To give a group its own colour, replace the value with a literal hex — but a
+     literal is theme-FIXED: to stay dark-aware it needs a matching override in the
+     html[data-theme="dark"] block below. E.g.
+         :root                   { --color-accent-1: #2646a6; }
+         html[data-theme="dark"] { --color-accent-1: #5b7fd6; }
+     One line if you don't want a dark variant, two if you do. */
+  --color-accent-1: var(--color-theme); /* MLSec */
+  --color-accent-2: var(--color-theme); /* PlatSec */
+  --color-accent-3: var(--color-theme); /* Other */
+
+  --color-status-success: var(--color-green);
+  --color-status-error: var(--color-red);
+
+  /* Footer (rendered in Stage 2; tokens defined now) */
+  --color-footer-bg: var(--color-grey-dark);
+  --color-footer-text: var(--color-grey-light);
+  --color-footer-link: var(--color-white);
+
+  /* Borders / rules */
+  --color-border-subtle: var(--color-divider-light); /* quiet dividers */
+  --color-border-default: var(--color-grey); /* standard rules */
+  --color-border-strong: var(--color-grey-dark); /* section breaks */
+
+  /* ─────────────────────────────
+     3. Typography — font families
+     Named families with a system fallback stack; no web-font downloads.
+     ───────────────────────────── */
+  --font-sans:
+    "Source Sans 3", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif;
+
+  --font-serif: "Source Serif 4", Georgia, "Times New Roman", Times, serif;
+
+  --font-mono:
+    "JetBrains Mono", SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+
+  /* Font sizes — modular, restrained */
+  --font-size-xs: 0.75rem; /* 12px */
+  --font-size-sm: 0.875rem; /* 14px */
+  --font-size-md: 1rem; /* 16px */
+  --font-size-lg: 1.125rem; /* 18px */
+  --font-size-xl: 1.25rem; /* 20px */
+  --font-size-2xl: 1.5rem; /* 24px */
+  --font-size-3xl: 1.875rem; /* 30px */
+  --font-size-4xl: 2.25rem; /* 36px */
+
+  /* Font weights */
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Line heights */
+  --line-height-tight: 1.25;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.65;
+
+  /* Spacing — 8px grid */
+  --space-0: 0;
+  --space-1: 0.25rem; /* 4px */
+  --space-2: 0.5rem; /* 8px */
+  --space-3: 0.75rem; /* 12px */
+  --space-4: 1rem; /* 16px */
+  --space-5: 1.5rem; /* 24px */
+  --space-6: 2rem; /* 32px */
+  --space-7: 3rem; /* 48px */
+  --space-8: 4rem; /* 64px */
+
+  /* Radii — restrained tiers */
+  --radius-none: 0;
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 8px;
+
+  /* Max widths — content discipline */
+  --max-width-xs: 32rem; /* ~512px */
+  --max-width-sm: 40rem; /* ~640px */
+  --max-width-md: 48rem; /* ~768px */
+  --max-width-lg: 64rem; /* ~1024px */
+}
+
+/* ─────────────────────────────
+   Dark mode — overrides SOURCE roles only.
+   --color-theme flips to cyan, so link/selection/accent-1..3 follow without
+   being re-declared. Raw palette and scales are untouched.
+   ───────────────────────────── */
+html[data-theme="dark"] {
+  --color-theme: var(--color-cyan);
+
+  --color-bg-default: var(--color-grey-dark);
+  /* Heavier mix than light: a 5% wash is invisible over a near-black page. */
+  --color-bg-muted: color-mix(
+    in srgb,
+    var(--color-theme) 14%,
+    var(--color-bg-default)
+  );
+  --color-surface: var(--color-grey-900);
+
+  --color-text-primary: var(--color-grey-light);
+  --color-text-secondary: var(--color-grey-light);
+  --color-text-muted: var(--color-grey-light);
+
+  --color-footer-bg: var(--color-grey-light);
+  --color-footer-text: var(--color-grey-dark);
+  --color-footer-link: var(--color-black);
+
+  --color-border-subtle: var(--color-divider-dark);
+  --color-border-default: var(--color-divider-dark);
+  --color-border-strong: var(--color-grey-light);
+}


### PR DESCRIPTION
Stage 1 of the Jekyll → Astro migration. PR into the `astro-migration` integration branch (not `main`).

## What

The design-system layer: CSS token architecture + the dark-mode layer + a theme toggle.

- **`src/styles/{tokens,base,layout,main}.css`** — three-layer tokens (raw palette → semantic roles → type/spacing/radii/width scales), mirroring the migration template's split.
- **Palette (resolves D1): keep the al-folio look.** Raw values lifted from the old Jekyll theme — purple `#b509ac` accent in light, cyan `#2698ba` in dark, bg `#fff`/`#1c1c1d`, text `#000`/`#e8e8e8`. The point of the stage is the architecture: no component reads a raw hex, so re-theming is a per-role edit in one file.
- **Dark mode** overrides *source* roles only. `--color-link`, `--color-selection`, and `--color-accent-1/2/3` indirect through `--color-theme`; because `:root` and `html[data-theme="dark"]` are the same `<html>` element, they re-resolve to the dark accent without being re-declared.
- **`--color-bg-muted` derives from `--color-theme`** via `color-mix()`, so inset/code surfaces track the accent instead of freezing to a fixed tint.
- **`--color-accent-1/2/3` → MLSec / PlatSec / Other** (all the single theme colour for now; a worked example for giving each its own — and a dark variant — is inlined in `tokens.css`).
- **`src/components/ThemeToggle.astro`** — the site's only runtime JS; flips and persists `html[data-theme]` to `localStorage`.
- **`src/pages/index.astro`** — a temporary token + dark-mode **demo harness**. The no-flash `<head>` script and the toggle move into `BaseLayout` in Stage 2; this page is replaced by the catch-all route in Stage 3.

## Verification

- `npm run ci` green (lint → format:check → markdownlint → astro check → build → vitest); `npm audit --audit-level=high` clean.
- Playwright against `astro preview`: light and dark both render; toggle sets `data-theme` and persists across reload; no flash on hard refresh; `--color-accent-1` computes purple in light / cyan in dark with no re-declaration; setting `--color-theme` to an arbitrary colour recolours the muted surface (proving it is no longer frozen).