### PR TITLE
Stage 4: sticky/translucent header + trailing-slash URL parity

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,7 +1,8 @@
 {
   "extends": ["html-validate:recommended"],
   "rules": {
-    "no-inline-style": "off",
-    "long-title": "off"
+    "long-title": "off",
+    "meta-refresh": "off",
+    "doctype-style": "off"
   }
 }

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,21 @@ import rehypeExternalLinks from "rehype-external-links";
 export default defineConfig({
   site: "https://ssg-research.github.io",
   integrations: [sitemap()],
+  // Every URL is trailing-slash (the consistent convention chosen in Stage 4,
+  // after the parity discussion). Each page builds to `dir/index.html` and Astro
+  // normalises paths to end in a slash, so canonical/og:url and internal links
+  // are uniform. The live site's no-slash project URLs (e.g. /platsec/blime)
+  // still resolve: GitHub Pages 301-redirects a no-slash request to its
+  // `dir/index.html`. URL parity is measured slash-agnostically (the visible URL
+  // matches), not by exact on-disk filename.
+  trailingSlash: "always",
+  build: { format: "directory" },
+  // The two `redirect_from` aliases from the live site, emitted as static
+  // redirect pages at `dir/index.html` so `/blime/` → `/platsec/blime/`.
+  redirects: {
+    "/blime/": "/platsec/blime/",
+    "/probandroid/": "/platsec/probandroid/",
+  },
   markdown: {
     // Astro 6.4 moved remark/rehype config out of `markdown.rehypePlugins`
     // into a `unified()` processor. External links open in a new tab with a

--- a/docs/lint-suppressions.md
+++ b/docs/lint-suppressions.md
@@ -1,0 +1,15 @@
+# html-validate rule suppressions
+
+`npm run htmlvalidate` validates the built `dist/**/*.html` against
+`html-validate:recommended`. A few rules are turned off in `.htmlvalidate.json`;
+each is recorded here with its reason so the config does not become a black box.
+
+| Rule            | Why it is off                                                                                                                                                                                                                                                                                                                                       |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `long-title`    | `/mlsec/interactions/` has a 74-character `<title>` ("Unintended Interactions among ML Risks and Defenses \| Secure Systems Group"). The string is faithful to the source content — `<page title> \| <site name>` — and `long-title` is an SEO guideline, not a validity error.                                                                     |
+| `meta-refresh`  | `404.astro` ports the live al-folio 404 behaviour, which auto-returns to the home page after a short delay (`<meta http-equiv="refresh" content="3; url=/">`). The rule forbids a non-zero refresh delay (WCAG 2.2.1). The behaviour is intentionally faithful; the accessibility concern is tracked as a follow-up to revisit after the migration. |
+| `doctype-style` | Astro's auto-generated redirect pages (from the `redirects` config — `/blime/`, `/probandroid/`) emit a lowercase `<!doctype html>`, while its `.astro` pages emit uppercase. The HTML5 doctype is case-insensitive, so this is a purely stylistic rule failing on framework output we do not control.                                              |
+
+When any of these conditions no longer holds — the long title is shortened, the
+404 drops its auto-refresh, or Astro normalises its redirect-page doctype — the
+corresponding rule should be re-enabled.

--- a/src/components/Masthead.css
+++ b/src/components/Masthead.css
@@ -4,7 +4,30 @@
    aligns with the content column. Mobile collapses the nav into a JS-free
    <details> menu. */
 
+/* Pinned to the top and translucent, like the live al-folio fixed navbar.
+   `position: sticky` (not `fixed`) keeps the bar in normal flow, so it reserves
+   its own height and the content below clears it automatically — no fixed offset
+   to hand-maintain. It still stays glued to the top through the whole scroll
+   (its containing block is the full-height .page), and content scrolls underneath
+   it once pinned. Faithful to the live computed style: an OPAQUE background token
+   plus opacity: 0.95 on the whole element (live computes background
+   rgb(255,255,255) / rgb(28,28,29) with opacity 0.95 — not a translucent rgba
+   background), so underlying content shows through faintly. Dark mode tracks
+   automatically: --color-bg-default and --color-border-subtle flip in the dark
+   token layer (live dark navbar is #1c1c1d / #424246 at the same 0.95).
+   z-index 1030 is Bootstrap's .fixed-top value — above all page content; the
+   opacity < 1 also opens a stacking context, so the mobile menu's scrim/summary/
+   panel z-indices below resolve within the masthead and the whole group floats
+   above content. (opacity does not become the fixed scrim's containing block —
+   only transform/filter/contain do — so the scrim stays viewport-anchored.) */
 .masthead {
+  position: sticky;
+  top: 0;
+  z-index: 1030;
+
+  background-color: var(--color-bg-default);
+  opacity: 0.95;
+
   border-bottom: 1px solid var(--color-border-subtle);
 }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,6 +37,8 @@ const description =
 // (matches the live al-folio <title>).
 const documentTitle = pageTitle ? `${pageTitle} | ${SITE.name}` : SITE.name;
 
+// trailingSlash: "always" makes Astro.url.pathname end in a slash for every
+// page, so canonical/og:url are uniform (e.g. /platsec/blime/).
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImageURL = new URL(SITE.ogImage, Astro.site);
 ---
@@ -100,6 +102,9 @@ const ogImageURL = new URL(SITE.ogImage, Astro.site);
           : "light");
       document.documentElement.dataset.theme = theme;
     </script>
+
+    <!-- Page-level <head> extras (e.g. the 404 page's meta-refresh). -->
+    <slot name="head" />
   </head>
 
   <body>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,38 @@
+---
+// The site 404. Astro always emits this route as `404.html` (regardless of
+// build.format), which GitHub Pages serves for any unknown path — matching the
+// live Jekyll 404. Ported faithfully from the live al-folio 404 (page layout +
+// a 3-second meta-refresh back to home).
+import BaseLayout from "../layouts/BaseLayout.astro";
+
+const title = "Page not found";
+const description = "Looks like there has been a mistake. Nothing exists here.";
+---
+
+<BaseLayout title={title} description={description}>
+  <meta slot="head" http-equiv="refresh" content="3; url=/" />
+
+  <header class="post-header">
+    <h1 class="post-title">{title}</h1>
+    <p class="post-description">{description}</p>
+  </header>
+
+  <article>
+    <p>
+      You will be redirected to the main page within 3 seconds. If not
+      redirected, please go back to the <a href="/">home page</a>.
+    </p>
+  </article>
+</BaseLayout>
+
+<style>
+  .post-header {
+    margin-bottom: var(--space-5);
+  }
+
+  .post-description {
+    margin-top: 0;
+    margin-bottom: var(--space-6);
+    font-size: var(--font-size-sm);
+  }
+</style>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -7,11 +7,13 @@ import { SITE } from "../constants/site";
 type ContentEntry = CollectionEntry<"pages"> | CollectionEntry<"projects">;
 
 export async function getStaticPaths() {
-  // Turn a permalink into a catch-all slug: strip leading/trailing slashes so
+  // Turn a permalink into a catch-all slug: strip surrounding slashes so
   // `/` → undefined (the home index) and `/platsec/blime` → "platsec/blime".
-  // Defined inside getStaticPaths — Astro evaluates it in an isolated chunk, so
-  // module-scope helpers it references can be tree-shaken away. Plain string
-  // ops (no regex) per repo convention.
+  // `build.format: "directory"` + `trailingSlash: "always"` then emits every
+  // page as `slug/index.html` (served at a trailing-slash URL). Defined inside
+  // getStaticPaths — Astro evaluates it in an isolated chunk, so module-scope
+  // helpers it references can be tree-shaken away. Plain string ops (no regex)
+  // per repo convention.
   function toSlug(permalink: string): string | undefined {
     let s = permalink;
     while (s.startsWith("/")) s = s.slice(1);

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -15,7 +15,8 @@
   flex: 1 0 auto;
   width: min(100% - (2 * var(--space-6)), var(--max-width-lg));
   margin-inline: auto;
-  /* ~48px gap below the masthead band (matches the live mt-5 offset) */
+  /* The masthead is `position: sticky`, so it reserves its own height in flow;
+     this is just the gap below it (the live mt-5 offset). */
   padding-top: var(--space-7);
   padding-bottom: var(--space-7);
 }


### PR DESCRIPTION
Stage 4 of the Jekyll→Astro migration. Two goals: pin the masthead like the live site, and reach URL parity. PR into `astro-migration` (not `main`).

## Sticky / translucent header
- `.masthead` is `position: sticky; top: 0; z-index: 1030` with an opaque theme-bg + `opacity: 0.95` — the live al-folio translucency mechanism (content shows through faintly when scrolled under it). Dark mode tracks via the existing tokens; no component-level dark CSS.
- `sticky` (vs the live `fixed`) keeps the bar in flow, so content clearance is **automatic** — no hardcoded offset token to drift out of sync.
- Mobile `<details>` menu + scrim z-index verified under the opacity stacking context, both themes, 390×844.

## URL parity
- **Standardised on trailing-slash URLs** (`trailingSlash: "always"` + `build.format: "directory"`) rather than reproducing the live site's mixed slash/no-slash filenames (an al-folio quirk). Parity is measured on the **visible URL** (never contains `index.html`/`.html`) and is **identical across all 20 URLs**.
- Legacy no-slash project links (e.g. `/platsec/blime`) resolve via GitHub Pages' directory → trailing-slash 301 (host behaviour; verified at deploy in Stage 7, since `astro preview` 404s the no-slash form).
- A single catch-all `[...slug].astro` renders every page.
- Config `redirects` for the `/blime/` and `/probandroid/` aliases.

## Also
- `404.astro` — faithful port of the live 404 (3s meta-refresh to home); `BaseLayout` gains a `<slot name="head" />` for it.
- `docs/lint-suppressions.md` documents the three html-validate rules turned off (`long-title`, `meta-refresh`, `doctype-style`); the now-unused `no-inline-style` rule was removed.

## Trade-off to note
Content sits ~7px lower than live (≈111 vs 104) because `sticky` reserves the bar's true height instead of the hardcoded offset `fixed` used. The gap *below* the bar is now exactly the faithful 48px. Reverting to `fixed` for the exact-104 match is a one-line change.

## Follow-ups
- #19 — the 404's timed auto-redirect (WCAG 2.2.1); kept faithful this pass.

## Verification
- `npm run ci` (lint → format:check → markdownlint → astro check → build → html-validate → vitest) green.
- `npm audit --audit-level=high` clean.
- Visible-URL parity diff empty (20/20); `/mlsec/template` absent (404 preserved).
- Header + dark mode + mobile menu checked via Playwright against `astro preview`.