### PR TITLE
Stage 5: bibliography component (papers.bib loader + <Publications>)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,11 +1,12 @@
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
+import mdx from "@astrojs/mdx";
 import { unified } from "@astrojs/markdown-remark";
 import rehypeExternalLinks from "rehype-external-links";
 
 export default defineConfig({
   site: "https://ssg-research.github.io",
-  integrations: [sitemap()],
+  integrations: [sitemap(), mdx()],
   // Every URL is trailing-slash (the consistent convention chosen in Stage 4,
   // after the parity discussion). Each page builds to `dir/index.html` and Astro
   // normalises paths to end in a slash, so canonical/og:url and internal links

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
+        "@astrojs/mdx": "^6.0.3",
         "@eslint/js": "^10.0.1",
         "@fontsource/roboto": "^5.2.10",
+        "@retorquere/bibtex-parser": "^10.0.0",
         "eslint": "^10.4.1",
         "eslint-plugin-astro": "^1.7.0",
         "html-validate": "^11.5.3",
@@ -143,6 +145,41 @@
         "unist-util-visit": "^5.1.0",
         "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/mdx": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-6.0.3.tgz",
+      "integrity": "sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "es-module-lexer": "^2.0.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-satteri": "0.3.0",
+        "astro": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-satteri": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/prism": {
@@ -1747,6 +1784,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@mdx-js/mdx/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1802,6 +1887,33 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@pomgui/deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pomgui/deep/-/deep-3.0.3.tgz",
+      "integrity": "sha512-xTLqLKASCb3OkM/tySjESKAhXGQt5pp/MPGDmMh21wuGHFnMU2VriIs1tIT9KPoJsS70PxOCGogrvD8OKojdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@retorquere/bibtex-parser": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@retorquere/bibtex-parser/-/bibtex-parser-10.0.0.tgz",
+      "integrity": "sha512-1rAGZ1RcgLJN5f6m8utgNJWlahmbiUEJuVZ2ILsQRCtNldDNE9/hdsXWhe25czHpyORjvVefImJeZJPqD8LZEQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@unified-latex/unified-latex-util-pegjs": "^1.8.4",
+        "@unified-latex/unified-latex-util-print-raw": "^1.8.4",
+        "@unified-latex/unified-latex-util-replace": "^1.8.4",
+        "@unified-latex/unified-latex-util-visit": "^1.8.4",
+        "i": "^0.3.7",
+        "lodash.merge": "^4.6.2",
+        "moo": "^0.5.3",
+        "nearley": "^2.20.1",
+        "unicode2latex": "^7.0.30",
+        "wink-eng-lite-web-model": "^1.8.1",
+        "wink-nlp": "^2.4.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -2350,6 +2462,16 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -2381,6 +2503,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2656,6 +2785,289 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@unified-latex/unified-latex-types": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-types/-/unified-latex-types-1.8.4.tgz",
+      "integrity": "sha512-nQ6YS4WYVOA89qdmxw57vl3KfmRGFHGTyLsw9LxCC7DSE6oma3rvXIGjBDUe7E3bgWocBqRITPcz25VqCRlFzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@unified-latex/unified-latex-util-match": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-match/-/unified-latex-util-match-1.8.4.tgz",
+      "integrity": "sha512-wYhTER8i3THQcTYjSufCr8IC0TxguN3dj3h0EFAVneZQ/FIqi/kbvvtPaI0u8mtQLuBDGfhftBy7PvuK9TSG3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.4",
+        "@unified-latex/unified-latex-util-print-raw": "^1.8.4"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-pegjs": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-pegjs/-/unified-latex-util-pegjs-1.8.4.tgz",
+      "integrity": "sha512-5PTvl2zTK25+Dy8SMpqq6Nf9k1gvr89fS7rR3hB8vi/KjA9AfXGQbiYOcwTfN8O5lpoKJeOuXw6hhaSlTpRaMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.4",
+        "@unified-latex/unified-latex-util-match": "^1.8.4"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-print-raw": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-print-raw/-/unified-latex-util-print-raw-1.8.4.tgz",
+      "integrity": "sha512-35hce9A8frQvEp5cM5avPpLMCUs8OIzhR3OZr4TjMJI/Lsj4wu6Tv9h2XQpxDmg8ofOtxn2UEWB19Wld9fgRvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.4"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-replace/-/unified-latex-util-replace-1.8.4.tgz",
+      "integrity": "sha512-9T2U11L6gihcoCul+xxwQOQrG3b8y5EcXvNXAV5U4c9GkLesvEEQ7wgyVtYtEDHIzFFL6p0Bc60XyWTn8VD3Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.4",
+        "@unified-latex/unified-latex-util-match": "^1.8.4",
+        "@unified-latex/unified-latex-util-split": "^1.8.4",
+        "@unified-latex/unified-latex-util-trim": "^1.8.4",
+        "@unified-latex/unified-latex-util-visit": "^1.8.4",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-split": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-split/-/unified-latex-util-split-1.8.4.tgz",
+      "integrity": "sha512-EZm92GRiOLcJeH/HFfh1unH+BBBGHOlvgjzIvG5I5XofLWj/Y2lwX2aPbNfrT/nmjKrujcUqPVAQPS8U2ydnpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.4",
+        "@unified-latex/unified-latex-util-match": "^1.8.4"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-trim/-/unified-latex-util-trim-1.8.4.tgz",
+      "integrity": "sha512-Da6vw1XyFxj1uk2p5cxOJXRMVhM/HEaf0SG8R+G1XUEJOmglicSoJOqRIAkpDrLOBZLebAiiXWmjbtIQzbhKkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.4",
+        "@unified-latex/unified-latex-util-match": "^1.8.4",
+        "@unified-latex/unified-latex-util-visit": "^1.8.4",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-visit": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-visit/-/unified-latex-util-visit-1.8.4.tgz",
+      "integrity": "sha512-m5O9evxr/kiX1awZAcwUQL+8slVvlWlkbZoKFDP1agrp3dpk7+69npqyoapKKJEK0B4uRYmv93Ho31oHgNoJrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.8.4",
+        "@unified-latex/unified-latex-util-match": "^1.8.4"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
@@ -3041,6 +3453,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
       }
     },
     "node_modules/astro": {
@@ -3547,6 +3969,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3883,6 +4316,13 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -4034,6 +4474,40 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -4284,6 +4758,104 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/estree-walker": {
@@ -4849,6 +5421,35 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -4866,6 +5467,34 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.0",
         "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5083,6 +5712,15 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5140,6 +5778,13 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -5435,6 +6080,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/just-permutations": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/just-permutations/-/just-permutations-2.2.1.tgz",
+      "integrity": "sha512-J2W9djsAsl346A9H41H/S8VXfnPjxZSFfBbAsZRbtFUQTpfmGBGJLWNeZgoDtzBw+ZaN7WF/DOsAJ+V/e6P5cQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/katex": {
       "version": "0.16.47",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
@@ -5591,6 +6243,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -5715,6 +6374,19 @@
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-it": {
@@ -6018,6 +6690,87 @@
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
       "license": "MIT",
       "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -6363,6 +7116,113 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -6404,6 +7264,34 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -6607,6 +7495,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
@@ -6802,6 +7716,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -6846,6 +7767,36 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7465,6 +8416,27 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -7477,6 +8449,77 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/regex": {
@@ -7568,6 +8611,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
@@ -7595,6 +8654,21 @@
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7725,6 +8799,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/retext": {
@@ -8102,6 +9186,16 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8209,6 +9303,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylelint": {
@@ -8577,6 +9691,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tiny-merge-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-merge-patch/-/tiny-merge-patch-1.0.0.tgz",
+      "integrity": "sha512-NR7dpqibfxA1uHaFJn5YXViH7REa0wPcZh8MLFrEn9OvDWyIY9YyyKHHmFBE66ER18CQwJ+VGknsQbgiBtL8Uw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8780,6 +9901,18 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/unicode2latex": {
+      "version": "7.0.33",
+      "resolved": "https://registry.npmjs.org/unicode2latex/-/unicode2latex-7.0.33.tgz",
+      "integrity": "sha512-Yk9tXwI/EVoLJzqAJfJpoUsY9ti5NV1aI2YpH4cg/n0q6Hj3Hnt/uT1nU27AqQFIgVpiT9SsNnAe56eTWuM/3g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@pomgui/deep": "^3.0.3",
+        "just-permutations": "^2.2.1",
+        "tiny-merge-patch": "^1.0.0"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
@@ -8868,6 +10001,20 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -9646,6 +10793,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wink-eng-lite-web-model": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/wink-eng-lite-web-model/-/wink-eng-lite-web-model-1.8.1.tgz",
+      "integrity": "sha512-M2tSOU/rVNkDj8AS8IoKJaM7apJJjS0cN+hE8CPazfnB4A/ojyc9+7RMPk18UOiIdSyWk7MR6w8z9lWix2l5tA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/wink-nlp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/wink-nlp/-/wink-nlp-2.4.0.tgz",
+      "integrity": "sha512-d02inlNJL0LLNTLoYfkxZYGrqnYDSZV4HI4WpeuyIEfpu7UcUqUW1ZYWr+JTFm4ZR6dQdzOW/FtHEQRO+o/zzA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
+    "@astrojs/mdx": "^6.0.3",
     "@eslint/js": "^10.0.1",
     "@fontsource/roboto": "^5.2.10",
+    "@retorquere/bibtex-parser": "^10.0.0",
     "eslint": "^10.4.1",
     "eslint-plugin-astro": "^1.7.0",
     "html-validate": "^11.5.3",

--- a/src/bibliography/papers.bib
+++ b/src/bibliography/papers.bib
@@ -1,0 +1,117 @@
+@inproceedings{blime24,
+  title = {BliMe: Verifiably Secure Outsourced Computation with Hardware-Enforced Taint Tracking},
+  author = {H ElAtali and L J Gunn and H Liljestrand and N Asokan},
+  booktitle = {Network and Distributed Systems Symposium (NDSS)},
+  location = {San Diego, CA, USA},
+  year = {2024},
+  isbn = {1-891562-93-2},
+  doi = {10.14722/ndss.2024.24105},
+  selected = {blime},
+  bibtex_show = {true},
+  abbr = {NDSS},
+  arxiv = {2204.09649},
+  html = {https://www.ndss-symposium.org/ndss-paper/blime-verifiably-secure-outsourced-computation-with-hardware-enforced-taint-tracking/}
+}
+
+@inproceedings{dolma24,
+  title = {Data-Oblivious ML Accelerators using Hardware Security Extensions},
+  author = {H ElAtali and J Z Jekel and L J Gunn and N Asokan},
+  booktitle = {IEEE International Symposium on Hardware Oriented Security and Trust (HOST)},
+  location = {Tysons Corner, VA, USA},
+  year = {2024},
+  doi = {10.1109/HOST55342.2024.10545398},
+  selected = {blime},
+  bibtex_show = {true},
+  abbr = {HOST},
+  arxiv = {2401.16583}
+}
+
+@inproceedings{blimeLinter24,
+  title = {BliMe Linter},
+  author = {H ElAtali and X Duan and H Liljestrand and M Xu and N Asokan},
+  booktitle={IEEE Secure Development Conference (SecDev)},
+  year = {2024},
+  doi = {10.1109/SecDev61143.2024.00011},
+  selected = {blime},
+  bibtex_show = {true},
+  abbr = {SecDev},
+  arxiv = {2406.15302}
+}
+
+@inproceedings{blackout25,
+  title = {BLACKOUT: Data-Oblivious Computation with Blinded Capabilities},
+  author = {H ElAtali and M Gülmez and T Nyman and N Asokan},
+  booktitle = {ACM Conference on Computer and Communications Security (CCS)},
+  year = {2025},
+  doi = {10.1145/3719027.3765169},
+  website = {https://blindedcapabilities.github.io/},
+  selected = {blime},
+  bibtex_show = {true},
+  abbr = {CCS},
+  arxiv = {2504.14654}
+}
+
+@inproceedings{magnet25,
+title = {MAGNET: Memory Tagging with Efficient Tag Prediction},
+author = {P Makkar and H ElAtali and A Caulfield and N Asokan},
+booktitle = {International Workshop on Hardware and Architectural Support for Security and Privacy},
+year = {2025},
+isbn = {9798400721984},
+publisher = {Association for Computing Machinery},
+doi = {10.1145/3768725.3768728},
+selected = {blime},
+bibtex_show = {true},
+abbr = {HASP}
+}
+
+@inproceedings {bluebird23,
+  author = {Parjanya Vyas and Asim Waheed and Yousra Aafer and N. Asokan},
+  title = {Auditing Framework {APIs} via Inferred App-side Security Specifications},
+  booktitle = {32nd USENIX Security Symposium (USENIX Security 23)},
+  year = {2023},
+  isbn = {978-1-939133-37-3},
+  address = {Anaheim, CA},
+  pages = {6061--6077},
+  url = {https://www.usenix.org/conference/usenixsecurity23/presentation/vyas},
+  publisher = {USENIX Association},
+  selected = {bluebird},
+  bibtex_show = {true},
+  month = aug
+}
+
+@inproceedings {ariadne25,
+  author = {Parjanya Vyas and Haseeb Ur Rehman Faheem and Yousra Aafer and N. Asokan},
+  title = {Ariadne: Navigating through the Labyrinth of Data-Driven Customization Inconsistencies in Android},
+  booktitle = {34th USENIX Security Symposium (USENIX Security 25)},
+  year = {2025},
+  isbn = {978-1-939133-52-6},
+  address = {Seattle, WA},
+  pages = {4245--4263},
+  url = {https://www.usenix.org/conference/usenixsecurity25/presentation/vyas},
+  publisher = {USENIX Association},
+  selected = {ariadne},
+  bibtex_show = {true},
+  month = aug
+}
+
+@inproceedings{semalloc,
+  title = {{SeMalloc: Semantics-Informed Memory Allocator}},
+  author = {Ruizhe Wang and Meng Xu and N. Asokan},
+  booktitle = {Proceedings of the 2024 ACM Conference on Computer and Communications Security (CCS)},
+  year = 2024,
+  month = 10,
+  address = {Salt Lake City, UT},
+  arxiv = {2402.03373},
+  selected = {malloc}
+}
+
+@inproceedings{s2malloc,
+  title = {{S2malloc: Statistically Secure Allocator for Use-After-Free Protection And More}},
+  author = {Ruizhe Wang and Meng Xu and N. Asokan},
+  booktitle = {Proceedings of the 2024 Conference on Detection of Intrusions and Malware \& Vulnerability Assessment (DIMVA)},
+  year = 2024,
+  month = 7,
+  address = {Lausanne, Switzerland},
+  arxiv = {2402.01894},
+  selected = {malloc}
+}

--- a/src/components/Publications.astro
+++ b/src/components/Publications.astro
@@ -1,0 +1,298 @@
+---
+import { getCollection, type CollectionEntry } from "astro:content";
+import "./Publications.css";
+
+type PublicationData = CollectionEntry<"publications">["data"];
+type Author = NonNullable<PublicationData["author"]>[number];
+
+interface Props {
+  selected?: string;
+}
+const { selected } = Astro.props;
+
+const allPublications = await getCollection("publications");
+const publications = allPublications
+  .filter((p) => !selected || p.data.selected === selected)
+  .sort((a, b) => {
+    const yearA = parseInt(a.data.year?.toString() || "0");
+    const yearB = parseInt(b.data.year?.toString() || "0");
+    return yearB - yearA;
+  });
+
+// Internal jekyll-scholar keywords stripped from the displayed BibTeX block,
+// mirroring `_config.yml`'s `filtered_bibtex_keywords` (the live `hideCustomBibtex`
+// filter). The link/flag fields are presentation metadata, not part of the citation.
+const FILTERED_BIBTEX_KEYWORDS = new Set([
+  "abbr",
+  "abstract",
+  "arxiv",
+  "bibtex_show",
+  "html",
+  "pdf",
+  "selected",
+  "supp",
+  "blog",
+  "code",
+  "poster",
+  "slides",
+  "website",
+  "preview",
+  "altmetric",
+]);
+
+const MONTH_ABBR = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+function escapeHTML(s: string) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// The parser yields month as a number (or numeric string); the live site shows
+// a capitalised three-letter abbreviation ("Oct", "Aug"). Fall back to
+// capitalising any non-numeric value rather than dropping it.
+function getMonthAbbr(month: string) {
+  const n = parseInt(month, 10);
+  if (!Number.isNaN(n) && n >= 1 && n <= 12) return MONTH_ABBR[n - 1];
+  return month.charAt(0).toUpperCase() + month.slice(1);
+}
+
+function getPeriodicalHTML(data: PublicationData) {
+  let emText = "";
+  const type = data.type?.toLowerCase() || "";
+  const proceedings = ["inproceedings", "incollection"];
+  const thesis = ["thesis", "mastersthesis", "phdthesis"];
+
+  if (type === "article") {
+    emText = data.journal || "";
+  } else if (proceedings.includes(type)) {
+    emText = data.booktitle ? `In ${data.booktitle}` : "";
+  } else if (thesis.includes(type)) {
+    emText = data.school || "";
+  }
+
+  emText = escapeHTML(emText);
+
+  const monthPart = data.month ? getMonthAbbr(String(data.month)) : "";
+  const yearPart = data.year != null ? String(data.year) : "";
+  const datePart = [monthPart, yearPart].filter(Boolean).join(" ");
+
+  let periodical = emText ? `<em>${emText}</em>` : "";
+  if (datePart) {
+    // Live always separates a non-empty venue from the year with ", "
+    // (a month-only tail gets a plain space — an edge the live data never hits).
+    if (periodical && yearPart) periodical += ", ";
+    else if (periodical) periodical += " ";
+    periodical += datePart;
+  }
+
+  return periodical;
+}
+
+// Drop the internal keyword lines from the raw BibTeX so the displayed entry
+// matches the live `hideCustomBibtex` output. A line's field name is everything
+// before its first "="; the entry/closing lines have no "=" and are kept.
+function getFilteredBibtex(raw: string) {
+  return raw
+    .split("\n")
+    .filter((line) => {
+      const eq = line.indexOf("=");
+      if (eq === -1) return true;
+      const key = line.slice(0, eq).trim().toLowerCase();
+      return !FILTERED_BIBTEX_KEYWORDS.has(key);
+    })
+    .join("\n");
+}
+
+function getAuthorHTML(authors: Author[] | undefined) {
+  if (!authors || authors.length === 0) return "";
+  const maxLimit = 3;
+  const showList = authors
+    .slice(0, maxLimit)
+    .map((a) => `${a.firstName || ""} ${a.lastName || ""}`.trim());
+  const moreList = authors
+    .slice(maxLimit)
+    .map((a) => `${a.firstName || ""} ${a.lastName || ""}`.trim());
+
+  let html = showList
+    .map((name, i) => {
+      // Separator carried as a suffix of the preceding name: middle authors get
+      // ", ", and the penultimate author (when the list is complete) gets the
+      // Oxford ", and " — matching the live "A, B, and C" form.
+      let suffix =
+        i < showList.length - 1
+          ? i === showList.length - 2 && moreList.length === 0
+            ? ", and "
+            : ", "
+          : "";
+      return escapeHTML(name) + suffix;
+    })
+    .join("");
+
+  if (moreList.length > 0) {
+    const moreText =
+      moreList.length === 1
+        ? "1 more author"
+        : `${moreList.length} more authors`;
+    // The revealed list is a plain comma-join of the hidden names, matching the
+    // live `more_authors_show` (no leading separator, no "and").
+    const moreNames = escapeHTML(moreList.join(", "));
+    html += `, and <span class="more-authors" data-more="${moreNames}" data-hide="${moreText}" onclick="const isShowing = this.textContent !== this.dataset.hide; this.textContent = isShowing ? this.dataset.hide : this.dataset.more;">${moreText}</span>`;
+  }
+  return html;
+}
+---
+
+<div class="publications">
+  {
+    publications.map(({ id, data }) => (
+      <div class="publication-row" id={id}>
+        <div class="publication-abbr">
+          {data.abbr && <abbr class="badge">{data.abbr}</abbr>}
+        </div>
+        <div class="publication-content">
+          <div class="title">{data.title}</div>
+          <div class="author" set:html={getAuthorHTML(data.author)} />
+          <div class="periodical" set:html={getPeriodicalHTML(data)} />
+          {data.note && <div class="periodical">{data.note}</div>}
+
+          <div class="publication-links">
+            {data.arxiv && (
+              <a
+                href={`https://arxiv.org/abs/${data.arxiv}`}
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                arXiv
+              </a>
+            )}
+            {data.html && (
+              <a
+                href={data.html}
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                HTML
+              </a>
+            )}
+            {data.pdf && (
+              <a
+                href={
+                  data.pdf.includes("://")
+                    ? data.pdf
+                    : `/assets/pdf/${data.pdf}`
+                }
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                PDF
+              </a>
+            )}
+            {data.supp && (
+              <a
+                href={
+                  data.supp.includes("://")
+                    ? data.supp
+                    : `/assets/pdf/${data.supp}`
+                }
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Supp
+              </a>
+            )}
+            {data.blog && (
+              <a
+                href={data.blog}
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Blog
+              </a>
+            )}
+            {data.code && (
+              <a
+                href={data.code}
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Code
+              </a>
+            )}
+            {data.poster && (
+              <a
+                href={
+                  data.poster.includes("://")
+                    ? data.poster
+                    : `/assets/pdf/${data.poster}`
+                }
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Poster
+              </a>
+            )}
+            {data.slides && (
+              <a
+                href={
+                  data.slides.includes("://")
+                    ? data.slides
+                    : `/assets/pdf/${data.slides}`
+                }
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Slides
+              </a>
+            )}
+            {data.website && (
+              <a
+                href={data.website}
+                class="btn btn-sm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Website
+              </a>
+            )}
+          </div>
+
+          {data.abstract && (
+            <details class="publication-details">
+              <summary class="btn btn-sm">Abs</summary>
+              <p>{data.abstract}</p>
+            </details>
+          )}
+
+          {data.bibtex_show && data.bibtex && (
+            <details class="publication-details">
+              <summary class="btn btn-sm">Bib</summary>
+              <pre>
+                <code>{getFilteredBibtex(data.bibtex)}</code>
+              </pre>
+            </details>
+          )}
+        </div>
+      </div>
+    ))
+  }
+</div>

--- a/src/components/Publications.css
+++ b/src/components/Publications.css
@@ -1,0 +1,104 @@
+.publications {
+  margin-top: var(--space-4);
+}
+
+.publication-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+}
+
+@media (width >= 640px) {
+  .publication-row {
+    flex-direction: row;
+    gap: var(--space-4);
+  }
+}
+
+.publication-abbr {
+  flex: 0 0 16.666%; /* equivalent to col-sm-2 */
+}
+
+.badge {
+  display: inline-block;
+  padding: 4px 8px;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-bg-default);
+  background-color: var(--color-text-primary);
+  border-radius: 4px;
+}
+
+.publication-content {
+  flex: 1;
+}
+
+.publication-content .title {
+  font-weight: 500;
+}
+
+.publication-content .author {
+  margin-top: 2px;
+}
+
+.publication-content .periodical {
+  font-size: var(--font-size-sm);
+  margin-top: 2px;
+}
+
+.publication-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.btn {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+  text-decoration: none;
+  background-color: transparent;
+  cursor: pointer;
+  line-height: 1.5;
+}
+
+.btn:hover {
+  background-color: var(--color-bg-muted);
+}
+
+.publication-details {
+  margin-top: var(--space-2);
+}
+
+.publication-details summary {
+  list-style: none; /* remove default arrow */
+}
+
+.publication-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.publication-details p,
+.publication-details pre {
+  margin-top: var(--space-2);
+  padding: var(--space-3);
+  background-color: var(--color-bg-muted);
+  border-radius: 4px;
+  font-size: var(--font-size-sm);
+}
+
+.publication-details pre {
+  overflow-x: auto;
+}
+
+.more-authors {
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: var(--font-size-sm);
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,47 +2,91 @@ import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "zod";
 
-// Two collections mirror the Jekyll source split:
-//   _pages/      → `pages`     (the about + the five nav sections)
-//   _projects/   → `projects`  (one page per research project)
-//
-// The schema is deliberately minimal: a contributor adding a page only needs a
-// `title` and a `permalink`, and gets a readable CI error for anything else.
-// Unlisted Jekyll frontmatter keys (display_categories, horizontal, layout …)
-// are dropped at migration time — they were unused by any surviving page.
-
 const pages = defineCollection({
   loader: glob({ pattern: "**/*.md", base: "./src/content/pages" }),
   schema: z.object({
     title: z.string(),
-    // The exact live URL, including its trailing slash where the live site has
-    // one (e.g. `/mlsec/`). The catch-all route emits this verbatim; Stage 4
-    // enforces the trailing-slash parity.
     permalink: z.string(),
     description: z.string().optional(),
-    // Home (`/`) only: the al-folio `about` subtitle, raw HTML (the three
-    // university links). Rendered with `set:html`.
     subtitle: z.string().optional(),
-    // Primary-nav membership and order. The masthead lists `nav: true` pages
-    // sorted by `nav_order` (About and the external Blog link are prepended).
-    nav: z.boolean().default(false),
+    nav: z.boolean().optional(),
     nav_order: z.number().optional(),
-    published: z.boolean().default(true),
+    published: z.boolean().optional(),
   }),
 });
 
 const projects = defineCollection({
-  loader: glob({ pattern: "**/*.md", base: "./src/content/projects" }),
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/projects" }),
   schema: z.object({
     title: z.string(),
     permalink: z.string(),
-    // Old URLs that should 301 to this page (e.g. `/blime/`). Wired into
-    // `astro.config.mjs` redirects in Stage 4.
     redirect_from: z.array(z.string()).optional(),
-    // `false` keeps a page out of the build (the contributor template). The
-    // catch-all skips it, preserving the live 404 at `/mlsec/template`.
-    published: z.boolean().default(true),
+    published: z.boolean().optional(),
   }),
 });
 
-export const collections = { pages, projects };
+const publications = defineCollection({
+  loader: {
+    name: "bibtex-loader",
+    async load({ store, parseData }) {
+      const { promises: fs } = await import("node:fs");
+      // @ts-expect-error No typings available for this package
+      const { parse } = await import("@retorquere/bibtex-parser");
+      const bibStr = await fs.readFile(
+        "./src/bibliography/papers.bib",
+        "utf-8"
+      );
+      // `sentenceCase: false` keeps titles and venues verbatim from the .bib.
+      // The parser's default sentence-casing would lowercase every word not
+      // brace-protected ("BliMe Linter" → "BliMe linter"), which diverges from
+      // the live site (jekyll-scholar renders the source casing as-is).
+      const parsed = parse(bibStr, { sentenceCase: false });
+      for (const entry of parsed.entries) {
+        const data = {
+          type: entry.type,
+          ...entry.fields,
+          bibtex: entry.input,
+        };
+        const parsedData = await parseData({ id: entry.key, data });
+        store.set({ id: entry.key, data: parsedData });
+      }
+    },
+  },
+  schema: z.object({
+    type: z.string(),
+    title: z.string(),
+    author: z
+      .array(
+        z.object({
+          lastName: z.string().optional(),
+          firstName: z.string().optional(),
+        })
+      )
+      .optional(),
+    booktitle: z.string().optional(),
+    journal: z.string().optional(),
+    school: z.string().optional(),
+    location: z.array(z.string()).optional(),
+    year: z.union([z.string(), z.number()]).optional(),
+    month: z.string().optional(),
+    isbn: z.string().optional(),
+    doi: z.string().optional(),
+    selected: z.string().optional(),
+    bibtex_show: z.string().optional(),
+    abbr: z.string().optional(),
+    arxiv: z.string().optional(),
+    html: z.string().optional(),
+    pdf: z.string().optional(),
+    supp: z.string().optional(),
+    blog: z.string().optional(),
+    code: z.string().optional(),
+    poster: z.string().optional(),
+    slides: z.string().optional(),
+    website: z.string().optional(),
+    abstract: z.string().optional(),
+    note: z.string().optional(),
+    bibtex: z.string().optional(),
+  }),
+});
+
+export const collections = { pages, projects, publications };

--- a/src/content/projects/platsec/blime.mdx
+++ b/src/content/projects/platsec/blime.mdx
@@ -13,11 +13,11 @@ Outsourced computing is widely used today. However, current approaches for prote
 
 We present Blinded Memory (BliMe), an architecture to realize efficient and secure outsourced computation. BliMe consists of a novel and minimal set of ISA extensions implementing a taint-tracking policy to ensure the confidentiality of client data even in the presence of server vulnerabilities. To secure outsourced computation, the BliMe extensions can be used together with an attestable, fixed-function hardware security module (HSM) and an encryption engine that provides atomic decrypt-and-taint and encrypt-and-untaint operations. Clients rely on remote attestation and key agreement with the HSM to ensure that their data can be transferred securely to and from the encryption engine and will always be protected by BliMe's taint-tracking policy while at the server.
 
-We provide a machine-checked security proof of BliMe extensions, and an RTL implementation BliMe-BOOM based on the BOOM RISC-V core. BliMe-BOOM incurs no reduction in clock frequency relative to unmodified BOOM, nor does it use significantly more power (<1.5%) or FPGA resources (≤9.0%). Various implementations of BliMe (on FPGA and the gem5 simulator) incur only moderate performance overhead (8-25%). We also provide a machine-checked security proof of a simplified model ISA with BliMe extensions.
+We provide a machine-checked security proof of BliMe extensions, and an RTL implementation BliMe-BOOM based on the BOOM RISC-V core. BliMe-BOOM incurs no reduction in clock frequency relative to unmodified BOOM, nor does it use significantly more power (&lt;1.5%) or FPGA resources (≤9.0%). Various implementations of BliMe (on FPGA and the gem5 simulator) incur only moderate performance overhead (8-25%). We also provide a machine-checked security proof of a simplified model ISA with BliMe extensions.
 
 ## Conference/journal paper publications
 
-<!-- TODO(bibliography): render papers with selected=blime -->
+<Publications selected="blime" />
 
 ## Doctoral Dissertations
 - Hossam ElAtali, [Hardware-Assisted Defenses for Data Integrity and Confidentiality](https://uwspace.uwaterloo.ca/items/b84f777e-53c1-4904-9c5a-b28931e4c7c7), University of Waterloo, 2025
@@ -37,6 +37,6 @@ We provide a machine-checked security proof of BliMe extensions, and an RTL impl
 - [BliMe-BOOM on Chipyard/FireSim](https://github.com/ssg-research/BliMe/tree/main/firesim)
 - [Formal model in F*](https://blinded-computation.github.io/blime-model/index.html)
 
-<!-- ## Follow-up work
+{/* ## Follow-up work
 
-- [BLACKOUT](https://blindedcapabilities.github.io/) -->
+- [BLACKOUT](https://blindedcapabilities.github.io/) */}

--- a/src/content/projects/platsec/memallo.mdx
+++ b/src/content/projects/platsec/memallo.mdx
@@ -12,7 +12,7 @@ Heap-related vulnerabilities, such as overflow, double-free, and use-after-free 
 
 ## Conference/journal paper publications
 
-<!-- TODO(bibliography): render papers with selected=malloc -->
+<Publications selected="malloc" />
 
 ## Source code
 

--- a/src/content/projects/platsec/probandroid.mdx
+++ b/src/content/projects/platsec/probandroid.mdx
@@ -17,9 +17,9 @@ To this end, we focus on (i) discovering various sources of hints that can provi
 
 ## Conference/journal paper publications
 
-<!-- TODO(bibliography): render papers with selected=bluebird -->
+<Publications selected="bluebird" />
 
-<!-- TODO(bibliography): render papers with selected=ariadne -->
+<Publications selected="ariadne" />
 
 ## Talks
 

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { SITE } from "../constants/site";
+import Publications from "../components/Publications.astro";
 
 type ContentEntry = CollectionEntry<"pages"> | CollectionEntry<"projects">;
 
@@ -78,7 +79,7 @@ const metaDescription =
   }
 
   <article>
-    <Content />
+    <Content components={{ Publications }} />
   </article>
 </BaseLayout>
 


### PR DESCRIPTION
Stage 5 of the Jekyll → Astro migration: the bibliography, replacing the legacy jekyll-scholar integration.

## What's here

- **`src/bibliography/papers.bib`** — the single source of truth (verbatim from the live site).
- **Custom inline content loader** (`src/content.config.ts`) parses the bib with `@retorquere/bibtex-parser` (`sentenceCase: false`, so titles/venues keep their source casing) into a `publications` collection keyed by citation key.
- **`<Publications selected="…">`** (`src/components/Publications.{astro,css}`) renders APA-style entries: venue badge, title, authors (with `max_author_limit: 3` truncation + reveal), periodical, link row (arXiv/HTML/PDF/Code/…), and `Abstract`/`BibTeX` `<details>`.
- **Three PlatSec pages → `.mdx`** (BliMe, Probably Android, Memory Allocation), with `<Publications>` injected via the catch-all route's `components` prop (`@astrojs/mdx` enabled).

## Rendering fidelity (matched to the deployed jekyll-scholar pages)

Verbatim title/venue casing, venue↔year comma, three-letter month abbreviation (`Jul`/`Oct`/`Aug`), Oxford comma, BibTeX block stripped of internal keywords (`hideCustomBibtex` parity), and faithful more-authors reveal text. Entry counts spot-checked against `grep selected papers.bib`: blime 5, bluebird 1, ariadne 1, malloc 2. Also restored the `zod`-from-`zod` import (the deprecated `astro:content` re-export had crept back, adding 48 `astro check` hints).

## Ordering — Fixes #21

Sorted **newest-first** (year descending), the chosen presentation. This is a deliberate departure from the live `--group_by none` `.bib`-file order.

## Verification

- `npm run ci` green end-to-end; `npm audit --audit-level=high` clean (8 moderate dev-only advisories, below the gate).
- Light/dark screenshot pass of all three pages (local, kept out of the repo).

## Follow-ups filed

- #22 — bibliography presentation is inconsistent across project pages (standardise on this component + add enforcement).
- #23 — venue badge needs a semantic colour scheme (per-venue or per-type) or removal.
- #24 — more-authors reveal omits "and" before the final author (faithful to live, but poor grammar).