### PR TITLE
Render the 3-column wiki reading list and rewrite its raw-HTML links

### DIFF
--- a/src/plugins/remark-wiki-links.mjs
+++ b/src/plugins/remark-wiki-links.mjs
@@ -2,11 +2,16 @@ import path from "node:path";
 import process from "node:process";
 import { visit } from "unist-util-visit";
 
-// Rewrites a wiki page's relative Markdown links (e.g. `../concepts/mi.md`,
+// Rewrites a wiki page's relative links (e.g. `../concepts/mi.md`,
 // `papers/README.md`) to absolute site URLs under the wiki base, resolving each
-// target against the page's own directory. Gated by file path: it only touches
-// files under the wiki content root, so `pages`/`projects` markdown is
-// untouched. External, mail/tel, and pure in-page anchors are left alone.
+// target against the page's own directory. Covers both Markdown links
+// (`[x](y.md)` → `link` nodes) and `<a href="y.md">` inside raw HTML blocks (the
+// reading-list `<table>` → opaque `html` nodes the `link` visitor never sees),
+// so the wiki's source links stay relative `.md` (resolving on GitHub, VS Code
+// and Obsidian) while the built site serves absolute URLs. Gated by file path:
+// it only touches files under the wiki content root, so `pages`/`projects`
+// markdown is left untouched. External, mail/tel, and pure in-page anchors are
+// left alone.
 export default function remarkWikiLinks(options = {}) {
   const base = options.base ?? "/dissemination/cs858wiki/";
   const contentRoot = path.resolve(
@@ -17,9 +22,14 @@ export default function remarkWikiLinks(options = {}) {
   return (tree, file) => {
     const filePath = file.path ?? (file.history && file.history[0]);
     if (!filePath || !filePath.startsWith(contentRoot)) return;
+    const fromDir = path.dirname(filePath);
 
-    visit(tree, "link", (node) => {
-      const url = node.url;
+    // Resolve one relative link to its site URL, or null to leave it as-is
+    // (external, mail/tel, in-page anchor, or — for raw HTML — a non-`.md`
+    // target the site doesn't own and shouldn't rewrite). `htmlOnly` guards the
+    // raw-HTML path: hand-written HTML can carry relative asset hrefs we must
+    // not touch, so there we only rewrite links that point at a `.md` page.
+    function resolve(url, htmlOnly) {
       if (
         !url ||
         url.includes("://") ||
@@ -27,22 +37,55 @@ export default function remarkWikiLinks(options = {}) {
         url.startsWith("tel:") ||
         url.startsWith("#")
       ) {
-        return;
+        return null;
       }
 
       const hashIdx = url.indexOf("#");
       const target = hashIdx === -1 ? url : url.slice(0, hashIdx);
       const anchor = hashIdx === -1 ? "" : url.slice(hashIdx);
-      if (target === "") return; // pure in-page anchor
+      if (target === "") return null; // pure in-page anchor
+      if (htmlOnly && !target.endsWith(".md")) return null;
 
-      const absTarget = path.resolve(path.dirname(filePath), target);
+      const absTarget = path.resolve(fromDir, target);
       let rel = path.relative(contentRoot, absTarget).split(path.sep).join("/");
 
       if (rel.endsWith("/README.md")) rel = rel.slice(0, -"/README.md".length);
       else if (rel === "README.md") rel = "";
       else if (rel.endsWith(".md")) rel = rel.slice(0, -".md".length);
 
-      node.url = (rel === "" ? base : `${base}${rel}/`) + anchor;
+      return (rel === "" ? base : `${base}${rel}/`) + anchor;
+    }
+
+    visit(tree, "link", (node) => {
+      const next = resolve(node.url, false);
+      if (next !== null) node.url = next;
+    });
+
+    // Walk each `href="..."` in raw HTML and rewrite the relative `.md` ones in
+    // place, leaving the surrounding markup untouched. Plain string scan (no
+    // regex) per repo convention; the wiki's HTML uses double-quoted hrefs.
+    visit(tree, "html", (node) => {
+      const marker = 'href="';
+      let out = "";
+      let i = 0;
+      for (;;) {
+        const start = node.value.indexOf(marker, i);
+        if (start === -1) {
+          out += node.value.slice(i);
+          break;
+        }
+        const valStart = start + marker.length;
+        const valEnd = node.value.indexOf('"', valStart);
+        if (valEnd === -1) {
+          out += node.value.slice(i);
+          break;
+        }
+        const url = node.value.slice(valStart, valEnd);
+        const next = resolve(url, true);
+        out += node.value.slice(i, valStart) + (next ?? url);
+        i = valEnd; // resume at the closing quote, preserving it
+      }
+      node.value = out;
     });
   };
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -178,6 +178,64 @@ thead th {
   font-weight: var(--font-weight-medium);
 }
 
+/* Section-header band: a `<th colspan>` inside `<tbody>` introduces a group of
+   rows (the reading list's themes). Left-aligned and a touch heavier than the
+   column headers, with a stronger top rule so each theme reads as a band. */
+tbody th[colspan] {
+  background-color: var(--color-bg-muted);
+  border-top: 2px solid var(--color-border-default);
+  font-weight: var(--font-weight-medium);
+  text-align: left;
+}
+
+/* Numeric first column (the reading `#`) stays compact so the topic and
+   reading columns get the width. */
+tbody td:first-child {
+  width: 1%;
+  white-space: nowrap;
+  color: var(--color-text-secondary);
+}
+
+/* Reading rows sit one step below body text — topic, titles and essential
+   links all read at `sm`, with the labels stepping down again to `xs` below.
+   Scoped via `:has` to rows carrying the `Primary` kicker so the Contents
+   table, which shares these cell positions, keeps body size. */
+tbody tr:has(td > strong:first-child) td {
+  font-size: var(--font-size-sm);
+}
+
+/* "Primary" kicker labelling the required reading, paired with the "Essential
+   readings" disclosure below it. A quiet medium-weight lead-in (strong is 500),
+   set in the secondary colour and a step smaller so it cues without competing
+   with the title. */
+td > strong:first-child {
+  display: block;
+  margin-bottom: var(--space-1);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+/* Essential readings collapsed under each primary reading. The summary is a
+   quiet, clickable affordance; the list sits indented when expanded. */
+td details {
+  margin-top: var(--space-2);
+}
+
+td summary {
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+td details[open] summary {
+  margin-bottom: var(--space-2);
+}
+
+td details ul {
+  margin: 0;
+  padding-left: var(--space-5);
+}
+
 /* ─────────────────────────────
    Rules
    ───────────────────────────── */


### PR DESCRIPTION
Site-side support for the restructured CS858 reading list (wiki change: ssg-research/cs858-wiki#4).

## Changes

- **Submodule pointer** bumped to current `cs858-wiki` `main`, which restructures the reading list into one **Topic** column and one **Reading** column (themes as `<th colspan>` band rows; each primary reading labelled "Primary" with its essential readings in a `<details>` disclosure). This bump also carries previously-merged wiki commits the site pointer had not yet picked up.
- **`remark-wiki-links.mjs`** now rewrites `href` attributes inside raw HTML blocks, not just Markdown links. The reading-list table is raw HTML (Markdown tables can't express the section-header rows / `<details>`), so its relative `.md` links were passing through unrewritten. They now resolve to absolute site URLs — base-prefixed with a trailing slash, e.g. `/dissemination/cs858wiki/papers/madry-2018-pgd/` — while staying relative `.md` in the wiki source so they remain browsable on GitHub / VS Code / Obsidian.
- **`base.css`** styles the layout: section-header band rows, the collapsible essential-readings disclosure, and the topic / title / label type scale.

## Verification

- Clean `astro build` succeeds; internal wiki links render base-prefixed with a trailing slash; external links untouched.
- `stylelint` clean; `vitest` passing.