### PR TITLE
Publish cs858 wiki at b53080c and move URL to /dissemination/cs858wiki-F26/

### DIFF
--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -39,8 +39,8 @@ export const BLOG_NAV: NavItem = {
 // URL, never linked from the masthead.
 export const WIKI = {
   // URL prefix for every wiki page. Leading and trailing slash required.
-  base: "/dissemination/cs858wiki/",
+  base: "/dissemination/cs858wiki-F26/",
   // Filesystem path (repo-root relative) the loader globs and the link
   // rewriter resolves relative `.md` targets against.
-  contentRoot: "vendor/cs858-wiki/wiki",
+  contentRoot: "vendor/cs858-wiki/wiki-f26",
 } as const;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -97,7 +97,7 @@ const publications = defineCollection({
 const wiki = defineCollection({
   loader: glob({
     pattern: "**/*.md",
-    base: "./vendor/cs858-wiki/wiki",
+    base: "./vendor/cs858-wiki/wiki-f26",
     // Preserve the file path verbatim as the id (minus `.md`). The glob
     // loader's default generateId slugifies — it lowercases `README` to
     // `readme`, which would break the README→directory mapping in

--- a/src/content/pages/cs858-papers-list.md
+++ b/src/content/pages/cs858-papers-list.md
@@ -2,7 +2,7 @@
 title: CS858 Paper List
 permalink: /dissemination/cs858-F26-papers-list/
 description: Reading list for CS858 (Trustworthy Machine Learning), Fall 2026
----claude
+---
 
 ## Part 1: Risks to trustworthiness in ML
 
@@ -20,7 +20,7 @@ description: Reading list for CS858 (Trustworthy Machine Learning), Fall 2026
 | 10 | [DAWN: Dynamic Adversarial Watermarking of Neural Networks](https://arxiv.org/abs/1906.00830) | Model Extraction and Distillation | Model Watermarking / Fingerprinting | [False Claims against Model Ownership Resolution](https://arxiv.org/abs/2304.06607); [Can LLM Watermarks Robustly Prevent Unauthorized Knowledge Distillation?](https://arxiv.org/abs/2502.11598) |
 | 11 | [Neural Cleanse: Identifying and Mitigating Backdoor Attacks in Neural Networks](http://people.cs.uchicago.edu/~ravenben/publications/pdf/backdoor-sp19.pdf) | Data Integrity and Supply-Chain Security | Training-data Poisoning | [BadNets: Identifying Vulnerabilities in the Machine Learning Model Supply Chain](https://arxiv.org/abs/1708.06733); [Poisoning Language Models During Instruction Tuning](https://arxiv.org/abs/2305.00944) |
 | 12 | [PoisonedRAG: Knowledge Corruption Attacks to Retrieval-Augmented Generation of Large Language Models](https://arxiv.org/abs/2402.07867) | Data Integrity and Supply-Chain Security | Preference Manipulation / RAG Poisoning | [Adversarial Search Engine Optimization for Large Language Models](https://arxiv.org/abs/2406.18382); [Certifiably Robust RAG against Retrieval Corruption](https://arxiv.org/abs/2405.15556) |
-| 13 | [Representation Engineering: A Top-Down Approach to AI Transparency](https://arxiv.org/abs/2310.01405) | Cross-Cutting Topics | Mechanistic Interpretability for AI safety | [Refusal in Language Models Is Mediated by a Single Direction](https://arxiv.org/abs/2406.11717); [Improving Alignment and Robustness with Circuit Breakers](https://arxiv.org/abs/2406.04313) |
+| 13 | [What Makes and Breaks Safety Fine-tuning? A Mechanistic Study](https://arxiv.org/abs/2407.10264) | Cross-Cutting Topics | Mechanistic Interpretability for AI safety | [Refusal in Language Models Is Mediated by a Single Direction](https://arxiv.org/abs/2406.11717); [Improving Alignment and Robustness with Circuit Breakers](https://arxiv.org/abs/2406.04313) |
 | 14 | [SoK: Unintended Interactions among Machine Learning Defenses and Risks](https://arxiv.org/abs/2312.04542) | Cross-Cutting Topics | Unintended Interactions among ML Defenses and Risks | [Conflicting Interactions Among Protection Mechanisms for Machine Learning Models](https://arxiv.org/abs/2207.01991); [Combining Machine Learning Defenses without Conflicts](https://arxiv.org/abs/2411.09776) |
 | 15 | [A Watermark for Large Language Models](https://arxiv.org/abs/2301.10226) | Cross-Cutting Topics | Media Forensics and Proactive Provenance | [Tree-Ring Watermarks: Fingerprints for Diffusion Images that are Invisible and Robust](https://arxiv.org/abs/2305.20030); [Media Forensics and DeepFakes: An Overview](https://arxiv.org/abs/2001.06564) |
 | 16 | [Examining Zero-Shot Vulnerability Repair with Large Language Models](https://arxiv.org/abs/2112.02125) | Cross-Cutting Topics | AI for Cybersecurity | [LLM Agents can Autonomously Exploit One-day Vulnerabilities](https://arxiv.org/abs/2404.08144); [AI Agents Enable Adaptive Computer Worms](https://arxiv.org/abs/2606.03811) |

--- a/src/plugins/remark-wiki-links.mjs
+++ b/src/plugins/remark-wiki-links.mjs
@@ -13,10 +13,10 @@ import { visit } from "unist-util-visit";
 // markdown is left untouched. External, mail/tel, and pure in-page anchors are
 // left alone.
 export default function remarkWikiLinks(options = {}) {
-  const base = options.base ?? "/dissemination/cs858wiki/";
+  const base = options.base ?? "/dissemination/cs858wiki-F26/";
   const contentRoot = path.resolve(
     process.cwd(),
-    options.contentRoot ?? "vendor/cs858-wiki/wiki"
+    options.contentRoot ?? "vendor/cs858-wiki/wiki-f26"
   );
 
   return (tree, file) => {


### PR DESCRIPTION
## What

- **Bump `vendor/cs858-wiki`** `2dbf64d → b53080c` (12 commits). This brings a site-wide editorial pass over the reading companions — tightened high-level overviews, deeper-context sections collapsed behind a `<details>` toggle, motivating questions removed, the "Primary" label renamed to "Assigned reading", and a per-page "Wiki Home" link. Paper set change: Representation Engineering removed, **Jain 2024 safety fine-tuning** added. New `under-construction.md` and several new concept pages.
- **Move the wiki URL** `/dissemination/cs858wiki/ → /dissemination/cs858wiki-F26/` (`WIKI.base`).
- **Track the submodule's content-dir rename** `wiki/ → wiki-f26/` in `WIKI.contentRoot` and the content-collection glob base. Without this the build produces zero wiki pages.
- **Regenerate** `src/content/pages/cs858-papers-list.md` from the updated `docs/CS858-F26-papers-stripped.xlsx` (only paper #13 changes in the table).

## Notes

- The URL slug `cs858wiki-F26` (capital F26) matches the existing `cs858-F26-papers-list` convention; the on-disk content dir stays lowercase `wiki-f26` (owned by the wiki repo), so `base` and `contentRoot` differ by design.
- The papers-list frontmatter previously closed with a stray `---claude` fence; the regeneration restores a clean `---`.

## Verification

`npm run ci` is green (lint, format, markdownlint, astro check, build, html-validate, tests). The build-output link test walks every page and confirms internal links — including the new relative "Wiki Home" links and raw-HTML reading-list/`<details>` hrefs — resolve under the new slug. No stale `cs858wiki/` output, no surviving `.md` hrefs, wiki absent from the home nav.