### PR TITLE
Pin VSCode to the workspace TypeScript SDK

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,7 @@
   "editor.formatOnSave": true,
   "[astro]": {
     "editor.defaultFormatter": "astro-build.astro-vscode"
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }


### PR DESCRIPTION
## What
Adds two settings to `.vscode/settings.json`:
```json
"typescript.tsdk": "node_modules/typescript/lib",
"typescript.enablePromptUseWorkspaceTsdk": true
```

## Why
After the astro 7 upgrade (#50), astro narrowed its package `exports` to `./tsconfigs/*.json`. VSCode's bundled TypeScript (5.x) doesn't resolve `extends: "astro/tsconfigs/strict"` through that exports shape and shows a false `File 'astro/tsconfigs/strict' not found` error on `tsconfig.json`. The workspace TypeScript (6.0.3) — the same one `astro check` and CI use — resolves it correctly.

Pinning the editor to the workspace SDK clears the spurious error and aligns editor diagnostics with CI.

## Notes
- The no-extension `extends` in `tsconfig.json` is intentionally unchanged. Adding `.json` (`astro/tsconfigs/strict.json`) breaks resolution under TS 6 (`TS6053`) and would fail CI; the no-extension form is correct.
- Editor-only change; no effect on build, type-check, or runtime. After merging, contributors reload the window (or run TypeScript: Select TypeScript Version → Use Workspace Version).