### PR TITLE
Skip CI/deploy for non-web changes; resize headings site-wide (#41), fix wiki toggle (#52)

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -19,8 +19,62 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    # `web` carries the path-detection result so the deploy job can gate on it
+    # too. The job itself ALWAYS runs to completion — it is the required status
+    # check on main, and a check is only reported when its job runs (a workflow
+    # skipped by a trigger-level path filter never reports, which would block
+    # every PR). Only the expensive steps below are gated, so an editor-config
+    # change (e.g. .vscode/) reports green in seconds without building.
+    outputs:
+      web: ${{ steps.changes.outputs.web }}
     steps:
+      # Decide whether anything that affects the built site changed. Runs before
+      # checkout: `gh api …/compare` reads the diff from the API, so no clone (or
+      # submodule fetch) is needed to make the call.
+      - name: Detect web-code changes
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Paths that never affect the built site. A change touching only these
+          # skips the build and deploy. Extend this list, not the build steps.
+          is_web_change() {
+            case "$1" in
+              .vscode/*) return 1 ;;
+              *) return 0 ;;
+            esac
+          }
+          base=""; head=""
+          case "${{ github.event_name }}" in
+            pull_request)
+              base="${{ github.event.pull_request.base.sha }}"
+              head="${{ github.event.pull_request.head.sha }}" ;;
+            push)
+              base="${{ github.event.before }}"
+              head="${{ github.sha }}" ;;
+          esac
+          # Manual runs and a branch's first push (no diff base) build as normal;
+          # a failed compare also falls through to web=true (fail safe — never
+          # skip a build we are unsure about).
+          web=true
+          if [ -n "$base" ] && [ -n "$head" ] \
+             && [ "$base" != "0000000000000000000000000000000000000000" ]; then
+            if files=$(gh api \
+                 "repos/${{ github.repository }}/compare/${base}...${head}" \
+                 --jq '.files[].filename' 2>/dev/null); then
+              web=false
+              while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                if is_web_change "$f"; then web=true; break; fi
+              done <<< "$files"
+            fi
+          fi
+          echo "web=$web" >> "$GITHUB_OUTPUT"
+          echo "Web-code changed: $web"
+
       - name: Checkout
+        if: steps.changes.outputs.web == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # cs858-wiki is a public submodule fetched over HTTPS, so it checks
@@ -28,48 +82,60 @@ jobs:
           submodules: recursive
 
       - name: Setup Node
+        if: steps.changes.outputs.web == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 26
           cache: npm
 
       - name: Install dependencies
+        if: steps.changes.outputs.web == 'true'
         run: npm ci --ignore-scripts
 
       - name: Audit dependencies
+        if: steps.changes.outputs.web == 'true'
         run: npm audit --audit-level=high
 
       - name: Lint (ESLint + Stylelint)
+        if: steps.changes.outputs.web == 'true'
         run: npm run lint
 
       - name: Format check
+        if: steps.changes.outputs.web == 'true'
         run: npm run format:check
 
       - name: Markdownlint
+        if: steps.changes.outputs.web == 'true'
         run: npm run markdownlint
 
       - name: Type check
+        if: steps.changes.outputs.web == 'true'
         run: npm run check
 
       - name: Build
+        if: steps.changes.outputs.web == 'true'
         run: npm run build
 
       - name: HTML validate
+        if: steps.changes.outputs.web == 'true'
         run: npm run htmlvalidate
 
       - name: Test
+        if: steps.changes.outputs.web == 'true'
         run: npm run test
 
       - name: Upload Pages artifact
+        if: steps.changes.outputs.web == 'true'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./dist
 
   deploy:
     needs: ci
-    # Deploy only from main (the cutover branch); never on integration-branch or
+    # Deploy only from main (the cutover branch) and only when web code actually
+    # changed (no artifact is produced otherwise); never on integration-branch or
     # PR runs, which still produce and validate the artifact above.
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: needs.ci.outputs.web == 'true' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -107,7 +107,7 @@ const metaDescription =
     margin-bottom: var(--space-5);
   }
 
-  /* .post-title is an <h1> — base.css already sizes it (40 / 300, live). */
+  /* .post-title is an <h1> — base.css already sizes it (28 / 300). */
 
   /* page-layout subtitle (e.g. "Machine Learning Security and Privacy"):
      0.875rem with a generous bottom gap. */

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -97,7 +97,7 @@ const metaDescription =
     )
   }
 
-  <article>
+  <article class:list={{ wiki: isWiki }}>
     <Content components={{ Publications }} />
   </article>
 </BaseLayout>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -54,12 +54,12 @@ h6 {
 /* h1 and h2 are large enough to hold the page on their own, so they stay at the
    body's light weight; h3–h6 keep the shared rule's regular (400). */
 h1 {
-  font-size: var(--font-size-4xl); /* 40px */
+  font-size: var(--font-size-2xl); /* 28px */
   font-weight: var(--font-weight-light); /* 300 */
 }
 
 h2 {
-  font-size: var(--font-size-3xl); /* 32px */
+  font-size: var(--font-size-xl); /* 24px */
   font-weight: var(--font-weight-light); /* 300 */
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -5,3 +5,4 @@
 @import url("./tokens.css");
 @import url("./base.css");
 @import url("./layout.css");
+@import url("./wiki.css");

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -94,16 +94,16 @@
     SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
 
-  /* Font sizes. base.css maps headings onto this scale: h1 40 / h2 32 / h3 20 /
+  /* Font sizes. base.css maps headings onto this scale: h1 28 / h2 24 / h3 20 /
      h4 16 / h5 16 / h6 16, body 16, small 14, footer 12. */
   --font-size-xs: 0.75rem; /* 12px — footer */
   --font-size-sm: 0.875rem; /* 14px — subtitle / small */
   --font-size-md: 1rem; /* 16px — body, nav, h4, h5, h6 */
-  --font-size-lg: 1.25rem; /* 20px — brand */
-  --font-size-xl: 1.5rem; /* 24px */
-  --font-size-2xl: 1.75rem; /* 28px */
-  --font-size-3xl: 2rem; /* 32px — h2 */
-  --font-size-4xl: 2.5rem; /* 40px — h1 */
+  --font-size-lg: 1.25rem; /* 20px — brand, h3 */
+  --font-size-xl: 1.5rem; /* 24px — h2 */
+  --font-size-2xl: 1.75rem; /* 28px — h1 */
+  --font-size-3xl: 2rem; /* 32px — spare upper rung */
+  --font-size-4xl: 2.5rem; /* 40px — spare upper rung */
 
   /* Font weights. Body and h1/h2 are light; h3–h6 step up to regular; strong/b
      and small UI accents use medium. */
@@ -112,7 +112,7 @@
   --font-weight-medium: 500; /* strong/b, table headers, badges, mobile menu */
 
   /* Line heights */
-  --line-height-tight: 1.2; /* headings (live: 48/40, 33.6/28) */
+  --line-height-tight: 1.2; /* headings (1.2 × font-size) */
   --line-height-normal: 1.5; /* body (live: 24/16) */
   --line-height-relaxed: 1.65;
 

--- a/src/styles/wiki.css
+++ b/src/styles/wiki.css
@@ -1,36 +1,20 @@
 /* Wiki content styling
    Scoped to the cs858 reading wiki: the catch-all route tags the <article> with
-   `class="wiki"` for wiki entries, so none of this touches the site's own pages.
-   Two concerns:
-     1. A tighter heading scale — the wiki leans on h1/h2 far more heavily than
-        the site's own pages (one h1 title, many h2 sections per paper), so each
-        steps down a rung.
-     2. The paper-page disclosure toggle (`<details><summary><h2>…`) — the source
-        keeps the heading inside <summary> so it renders at heading size when the
-        Markdown is viewed on GitHub; these rules align the marker with that
-        heading on the built site.
-   Both reuse existing tokens; the rest of the site is unchanged.
-*/
+   `class="wiki"` for wiki entries. This holds only the features the site's own
+   pages do not have; the heading scale lives in base.css and applies site-wide.
+   Two features: the paper-page disclosure toggle, and the "Wiki Home" nav banner.
 
-/* 1. Heading scale: h1 40→28, h2 32→24 (h3–h6 keep base.css sizes). */
-.wiki h1 {
-  font-size: var(--font-size-2xl); /* 28px */
-}
+   Paper-page disclosure toggle (`<details><summary><h2>…`): a heading inside
+   <summary> is block-level, so the native disclosure triangle drops onto its own
+   line above the heading (GitHub avoids this with `summary h2 { display:
+   inline-block }`; the site had no equivalent). Making <summary> a flex row lets
+   a custom triangle marker sit vertically centred against the heading at any
+   size — the native list-item marker cannot be centred, so it is removed and
+   replaced. The source keeps the heading inside <summary> so it still renders at
+   heading size when the Markdown is viewed on GitHub.
 
-.wiki h2 {
-  font-size: var(--font-size-xl); /* 24px */
-}
-
-/* 2. Paper-page toggle. Scoped to `.wiki > details` — a direct child of the
-   article — so the reading-list table's nested `td summary` toggles (styled in
-   base.css) are left alone.
-
-   A heading inside <summary> is block-level, so the native disclosure triangle
-   drops onto its own line above the heading (GitHub avoids this with
-   `summary h2 { display: inline-block }`; the site had no equivalent). Making
-   <summary> a flex row lets a custom triangle marker sit vertically centred
-   against the heading at any size — the native list-item marker cannot be
-   centred, so it is removed and replaced. */
+   Scoped to `.wiki > details` — a direct child of the article — so the reading
+   list table's nested `td summary` toggles (styled in base.css) are left alone. */
 .wiki > details {
   margin-block: var(--space-4);
 }
@@ -67,7 +51,19 @@
 }
 
 /* The heading carries the summary's text; zero its margins so the flex row stays
-   tight. Its font-size still comes from the .wiki h2 rule above. */
+   tight. Its font-size still comes from the site-wide heading rule in base.css. */
 .wiki > details > summary > :where(h1, h2, h3, h4, h5, h6) {
   margin: 0;
+}
+
+/* "Wiki Home" nav banner. Paper and concept pages open with `## [Wiki Home](…)`,
+   which renders as a first-child <h2> wrapping the home link. The site keeps
+   headings rule-free, so this nav otherwise sits flush against the page title; a
+   hairline rule plus spacing sets it off as a header strip. Guarded by `:has(a)`
+   and `:first-child` so it only matches the nav line — index pages open with an
+   <h1>, and section headings are never the article's first child. */
+.wiki > h2:first-child:has(a) {
+  padding-bottom: var(--space-2);
+  margin-bottom: var(--space-5);
+  border-bottom: 1px solid var(--color-border-subtle);
 }

--- a/src/styles/wiki.css
+++ b/src/styles/wiki.css
@@ -1,0 +1,73 @@
+/* Wiki content styling
+   Scoped to the cs858 reading wiki: the catch-all route tags the <article> with
+   `class="wiki"` for wiki entries, so none of this touches the site's own pages.
+   Two concerns:
+     1. A tighter heading scale — the wiki leans on h1/h2 far more heavily than
+        the site's own pages (one h1 title, many h2 sections per paper), so each
+        steps down a rung.
+     2. The paper-page disclosure toggle (`<details><summary><h2>…`) — the source
+        keeps the heading inside <summary> so it renders at heading size when the
+        Markdown is viewed on GitHub; these rules align the marker with that
+        heading on the built site.
+   Both reuse existing tokens; the rest of the site is unchanged.
+*/
+
+/* 1. Heading scale: h1 40→28, h2 32→24 (h3–h6 keep base.css sizes). */
+.wiki h1 {
+  font-size: var(--font-size-2xl); /* 28px */
+}
+
+.wiki h2 {
+  font-size: var(--font-size-xl); /* 24px */
+}
+
+/* 2. Paper-page toggle. Scoped to `.wiki > details` — a direct child of the
+   article — so the reading-list table's nested `td summary` toggles (styled in
+   base.css) are left alone.
+
+   A heading inside <summary> is block-level, so the native disclosure triangle
+   drops onto its own line above the heading (GitHub avoids this with
+   `summary h2 { display: inline-block }`; the site had no equivalent). Making
+   <summary> a flex row lets a custom triangle marker sit vertically centred
+   against the heading at any size — the native list-item marker cannot be
+   centred, so it is removed and replaced. */
+.wiki > details {
+  margin-block: var(--space-4);
+}
+
+.wiki > details > summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  list-style: none; /* drop the native marker (Firefox) */
+}
+
+/* WebKit/Blink expose the marker as a pseudo-element; hide it so only the custom
+   triangle shows. */
+.wiki > details > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* Custom marker: a right-pointing CSS triangle that rotates to point down when
+   open. currentColor tracks the heading colour, so it follows the active theme. */
+.wiki > details > summary::before {
+  content: "";
+  flex: none;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 5px 0 5px 8px;
+  border-color: transparent transparent transparent currentColor;
+  transition: transform 0.15s ease;
+}
+
+.wiki > details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+/* The heading carries the summary's text; zero its margins so the flex row stays
+   tight. Its font-size still comes from the .wiki h2 rule above. */
+.wiki > details > summary > :where(h1, h2, h3, h4, h5, h6) {
+  margin: 0;
+}


### PR DESCRIPTION
Site changes plus a cs858-wiki content publish.

## 1. Skip CI/deploy for non-web changes
The `ci-deploy` workflow decides whether a push/PR touches the built site before doing the expensive work. A **Detect web-code changes** step (always runs) reads the diff from the GitHub compare API and sets `web=true/false` based on whether anything outside `.vscode/` changed. Every build/lint/test step *and* the checkout are gated on `web == 'true'`, and `deploy` gates on `needs.ci.outputs.web == 'true'`.

The `ci` job itself always completes, so the **required `ci` status check still reports green** — a `.vscode`-only PR stays mergeable (no trigger-level path-filter deadlock). Detection is dependency-free (uses `gh api`, no new action) and fail-safe: manual runs, a branch's first push, and compare failures all build as normal.

## 2. Resize headings site-wide — Fixes #41
h1 40→28 and h2 32→24, applied in the shared `base.css` rule by repointing to the existing `--font-size-2xl` / `--font-size-xl` tokens. The whole site shares one scale (homepage hero, page titles, wiki). The `3xl`/`4xl` tokens remain defined as spare upper rungs.

## 3. Fix paper-page toggle alignment — Fixes #52
A heading inside `<summary>` is block-level, so the native disclosure triangle dropped onto its own line (GitHub avoids this with `summary h2 { display: inline-block }`; the site had no equivalent). The `<summary>` is now a flex row with a custom triangle marker **vertically centered** against the heading at any level, rotating when open. Scoped to `.wiki > details`, so the reading-list table toggles (`td summary`) keep their native styling. The source Markdown is untouched, so it still renders at heading size on GitHub.

## 4. "Wiki Home" nav banner
A hairline rule under the first-child "Wiki Home" nav heading on paper/concept pages, setting it off from the page title. Guarded by `:has(a)` + `:first-child`, so wiki index pages (which open with an `<h1>`) and section headings are untouched. Lives in `wiki.css`, which now holds only features the site's own pages lack (this and the toggle).

## Wiki content publish
Bumps the `cs858-wiki` submodule `b53080c → 424ec50` (restructured paper pages: reading-guidance order, Wiki Home banner heading, references heading level). The toggle CSS handles the new heading levels (Paper Context h2, References h4) — both verified centered.

## Testing
- Browser-verified: homepage hero + paper title 28px, section headings 24px, toggle marker-center == heading-center to the pixel, open-state rotation, Wiki Home banner present on paper pages and absent on index pages, `td summary` table toggles untouched.
- Full local CI green: lint, format:check, markdownlint, astro check (0 errors), build, htmlvalidate, test (5/5).